### PR TITLE
Fix link to trait attributes file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the repository which contains content for the Microsoft Test Framewor
 MSTest V2 API documentation is available [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.testtools.unittesting).
 
 ### Documentation
- - [Framework Extensibility Description Attributes](https://github.com/Microsoft/testfx-docs/blob/master/RFCs/001-Framework-Extensibility-Description-Attributes.md)
+ - [Framework Extensibility Trait Attributes](https://github.com/Microsoft/testfx-docs/blob/master/RFCs/001-Framework-Extensibility-Trait-Attributes.md)
  - [Framework Extensibility for Custom Assertions](https://github.com/Microsoft/testfx-docs/blob/master/RFCs/002-Framework-Extensibility-Custom-Assertions.md)
  - [Customize Running tests](https://github.com/Microsoft/testfx-docs/blob/master/RFCs/003-Customize-Running-Tests.md)
  - [In-assembly parallel execution](https://github.com/Microsoft/testfx-docs/blob/master/RFCs/004-In-Assembly-Parallel-Execution.md)


### PR DESCRIPTION
It looks like the filename for RFC 001 was changed from RFCs`001-Framework-Extensibility-Description-Attributes.md` to `001-Framework-Extensibility-Trait-Attributes.md` in 2652c9ae. This will update the readme to reflect that change.