### PR TITLE
Update RFC for MapNotRunnableToFailed Attribute

### DIFF
--- a/RFCs/010-MapNotRunnableToFailed-Attribute.md
+++ b/RFCs/010-MapNotRunnableToFailed-Attribute.md
@@ -1,7 +1,7 @@
 # RFC 010 - Map not runnable tests to failed via runsettings
 
 ## Motivation
-Some tests which have incompatible signature and cannot be executed are marked as skipped with warnings being thrown.
+Some tests which have incompatible signature and cannot be executed are skipped with warnings being thrown.
 User should be able to configure to fail a test if it is not runnable. 
 
 ### Proposed solution
@@ -17,4 +17,6 @@ Here is a sample runsettings: 
 ```
 
 ### Honoring the settings 
-- If no settings are provided in runsettings, default MapNotRunnableToFailed is set to false. This has been kept in regard with backward compatibility.
+- If no settings are provided in runsettings, default MapNotRunnableToFailed is set to true. 
+  This has been kept to fail the tests which cannot be executed and avoid silent failures.
+- The setting can be overridden by specifying `MapNotRunnableToFailed>false</MapNotRunnableToFailed>` in the adapter settings.

--- a/RFCs/010-MapNotRunnableToFailed-Attribute.md
+++ b/RFCs/010-MapNotRunnableToFailed-Attribute.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 Some tests which have incompatible signature and cannot be executed are skipped with warnings being thrown.
-User should be able to configure to fail a test if it is not runnable. 
+These tests will now be marked failed since these are not even being executed. User should be able to configure to not fail a test if it is not runnable in accordance with maintaining backward compatibility.
 
 ### Proposed solution
 Make this setting configurable via MapNotRunnableToFailed tag which is part of the adapter node in the runsettings.
@@ -19,4 +19,4 @@ Here is a sample runsettings: 
 ### Honoring the settings 
 - If no settings are provided in runsettings, default MapNotRunnableToFailed is set to true. 
   This has been kept to fail the tests which cannot be executed and avoid silent failures.
-- The setting can be overridden by specifying `MapNotRunnableToFailed>false</MapNotRunnableToFailed>` in the adapter settings.
+- The setting can be overridden by specifying `<MapNotRunnableToFailed>false</MapNotRunnableToFailed>` in the adapter settings.


### PR DESCRIPTION
MapNotRunnableToFailed default value is set to true to not allow silent failures from happening. Updating RFC for the same